### PR TITLE
Update home background images per theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
   return (
     <div>
       <Header dark={dark} setDark={setDark} />
-      <Home />
+      <Home dark={dark} />
       <About />
       <Skills />
       <Services />

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Typed from 'typed.js';
 import { supabase } from '../supabaseClient';
 
-export default function Home() {
+export default function Home({ dark }) {
   const [name, setName] = useState('Rafael Carvalho');
   const [desc, setDesc] = useState('');
 
@@ -35,6 +35,18 @@ export default function Home() {
 
   return (
     <section className="home" id="home">
+      <div className="home-image-wrapper">
+        <img
+          src="/images/dark.png"
+          alt="dark background"
+          className={`home-image ${dark ? 'visible' : ''}`}
+        />
+        <img
+          src="/images/light.png"
+          alt="light background"
+          className={`home-image ${dark ? '' : 'visible'}`}
+        />
+      </div>
       <div className="home-content">
         <h3>Hello, my name is</h3>
         <h1>{name}</h1>

--- a/src/index.css
+++ b/src/index.css
@@ -103,15 +103,47 @@ section {
 }
 
 .home {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
   background-attachment: fixed;
-  background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)), url('/images/portfolio1.jpg');
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
+}
+
+.home::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2));
+  z-index: 1;
+  pointer-events: none;
+}
+
+.home-image-wrapper {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.home-image {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.home-image.visible {
+  opacity: 1;
+}
+
+.home-content {
+  position: relative;
+  z-index: 2;
 }
 
 


### PR DESCRIPTION
## Summary
- use dark or light image on the home section
- fade between images when toggling theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684908f3e3f4833286aeb5f7265ea09c